### PR TITLE
feat: 로그아웃 및 탈퇴 기능 구현 및 리팩토링

### DIFF
--- a/src/main/java/com/example/pace/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/pace/domain/auth/controller/AuthController.java
@@ -6,7 +6,10 @@ import com.example.pace.domain.auth.exception.AuthSuccessCode;
 import com.example.pace.domain.auth.service.AuthCommandService;
 import com.example.pace.domain.member.exception.MemberSuccessCode;
 import com.example.pace.global.apiPayload.ApiResponse;
+import com.example.pace.global.apiPayload.code.GeneralSuccessCode;
+import com.example.pace.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,9 +18,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
     private final AuthCommandService authCommandService;
 
+    @Override
     @PostMapping("/kakao")
     public ApiResponse<AuthResDTO.LoginResultDTO> kakaoLogin(
             @RequestBody AuthReqDTO.KakaoLoginRequestDTO request
@@ -28,6 +32,7 @@ public class AuthController {
         );
     }
 
+    @Override
     @PostMapping("/reissue")
     public ApiResponse<AuthResDTO.LoginResultDTO> reissueToken(
             @RequestBody AuthReqDTO.ReissueRequestDTO request

--- a/src/main/java/com/example/pace/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/pace/domain/auth/controller/AuthControllerDocs.java
@@ -1,4 +1,36 @@
 package com.example.pace.domain.auth.controller;
 
+import com.example.pace.domain.auth.dto.request.AuthReqDTO;
+import com.example.pace.domain.auth.dto.response.AuthResDTO;
+import com.example.pace.domain.auth.dto.response.AuthResDTO.LoginResultDTO;
+import com.example.pace.global.apiPayload.ApiResponse;
+import com.example.pace.global.auth.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
 public interface AuthControllerDocs {
+    @Operation(
+            summary = "카카오 소셜 로그인",
+            description = "카카오 액세스 토큰을 보내면 회원 정보를 반환합니다."
+    )
+    @Parameters({
+            @Parameter(name = "kakaoAccessToken", description = "카카오로부터 받은 액세스 토큰입니다.")
+    })
+    ApiResponse<AuthResDTO.LoginResultDTO> kakaoLogin(
+            @RequestBody AuthReqDTO.KakaoLoginRequestDTO request
+    );
+
+    @Operation(
+            summary = "액세스 토큰 재발행",
+            description = "리프레쉬 토큰을 보내면 새 액세스 토큰을 재발행합니다."
+    )
+    @Parameters({
+            @Parameter(name = "refreshToken", description = "리프레쉬 토큰입니다.")
+    })
+    ApiResponse<LoginResultDTO> reissueToken(
+            @RequestBody AuthReqDTO.ReissueRequestDTO request
+    );
 }

--- a/src/main/java/com/example/pace/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/pace/domain/member/controller/MemberController.java
@@ -1,4 +1,49 @@
 package com.example.pace.domain.member.controller;
 
-public class MemberController {
+import com.example.pace.domain.auth.service.AuthCommandService;
+import com.example.pace.domain.member.service.MemberCommandService;
+import com.example.pace.global.apiPayload.ApiResponse;
+import com.example.pace.global.apiPayload.code.GeneralSuccessCode;
+import com.example.pace.global.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController implements MemberControllerDocs {
+    private final MemberCommandService memberCommandService;
+    private final AuthCommandService authCommandService;
+
+    @Override
+    @DeleteMapping("/withdrawal")
+    public ApiResponse<String> withdrawal(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long memberId = customUserDetails.member().getId();
+        memberCommandService.withdrawalMember(memberId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "회원 탈퇴가 완료되었습니다."
+        );
+    }
+
+    @Override
+    @PostMapping("/logout")
+    public ApiResponse<String> logout(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long memberId = customUserDetails.member().getId();
+        authCommandService.logout(memberId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "로그아웃 되었습니다."
+        );
+    }
 }

--- a/src/main/java/com/example/pace/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/example/pace/domain/member/controller/MemberControllerDocs.java
@@ -1,4 +1,27 @@
 package com.example.pace.domain.member.controller;
 
+import com.example.pace.global.apiPayload.ApiResponse;
+import com.example.pace.global.auth.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 public interface MemberControllerDocs {
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "Authorization 헤더에 Bearer {액세스 토큰} 을 넣으면 회원 정보 식별이 되므로, 회원id는 안보내도 됩니다!"
+    )
+    ApiResponse<String> withdrawal(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+
+    @Operation(
+            summary = "로그아웃",
+            description = "해당 API 성공 응답을 받으면 안드로이드 앱에서 반드시 기기에 저장된 액세스 토큰을 삭제해야 하고, 카카오 SDK를 통해 카카오 연결을 끊은 후(unlink) "
+                    + "로그인 페이지로 넘겨야 합니다."
+    )
+    ApiResponse<String> logout(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
 }

--- a/src/main/java/com/example/pace/domain/member/entity/Member.java
+++ b/src/main/java/com/example/pace/domain/member/entity/Member.java
@@ -10,6 +10,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -26,6 +29,12 @@ import org.hibernate.annotations.SQLRestriction;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "social_provider_id_unique",
+                columnNames = {"socialProvider", "socialId"}
+        )
+})
 @SQLDelete(sql = "UPDATE member SET is_active = false WHERE id = ?") // delete()시 hard delete 하는 것이 아닌 soft delete를 진행
 @SQLRestriction("is_active = true") // 조회시 isActive 필드가 true인 데이터만 조회
 public class Member extends BaseEntity {
@@ -37,17 +46,18 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @Column(nullable = false, unique = true)
+    @Column(name = "social_id", nullable = false)
     private String socialId; // 확장성을 위해 String 타입으로 필드 선언
 
+    @Column(name = "refresh_token")
     private String refreshToken;
 
     @NotBlank
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @NotNull
-    @Column(nullable = false)
+    @Column(name = "social_provider", nullable = false)
     @Enumerated(EnumType.STRING)
     private SocialProvider socialProvider;
 
@@ -56,7 +66,7 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Role role = Role.ROLE_USER;
 
-    @Column(nullable = false)
+    @Column(name = "is_active", nullable = false)
     @Builder.Default
     private Boolean isActive = true;
 

--- a/src/main/java/com/example/pace/domain/member/enums/Role.java
+++ b/src/main/java/com/example/pace/domain/member/enums/Role.java
@@ -1,6 +1,6 @@
 package com.example.pace.domain.member.enums;
 
 public enum Role {
-    ROLE_IMCOMPLETE_USER, // 온보딩을 완료하지 않은 사용자
+    ROLE_INCOMPLETE_USER, // 온보딩을 완료하지 않은 사용자
     ROLE_USER
 }

--- a/src/main/java/com/example/pace/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/pace/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.pace.domain.member.repository;
 
 import com.example.pace.domain.member.entity.Member;
+import com.example.pace.domain.member.enums.SocialProvider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,8 +12,11 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     // 이메일로 모든 상태(활성, 탈퇴)의 회원을 조회
     // @SQLRestriction 을 우회하기 위해 네이티브 쿼리 사용
-    @Query(value = "SELECT * FROM member WHERE email = :email", nativeQuery = true)
-    Optional<Member> findByEmailIgnoreStatus(@Param("email") String email);
+    @Query(value = "SELECT * FROM member WHERE social_provider = :socialProvider AND social_id = :socialId", nativeQuery = true)
+    Optional<Member> findBySocialProviderAndSocialIdIgnoreStatus(
+            @Param("socialProvider") String socialProvider,
+            @Param("socialId") String socialId
+    );
 
     @Query(value = "SELECT * FROM member WHERE id = :memberId", nativeQuery = true)
     Optional<Member> findByIdIgnoreStatus(@Param("memberId") Long memberId);

--- a/src/main/java/com/example/pace/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/pace/domain/member/service/MemberCommandService.java
@@ -1,4 +1,24 @@
 package com.example.pace.domain.member.service;
 
+import com.example.pace.domain.member.entity.Member;
+import com.example.pace.domain.member.exception.MemberErrorCode;
+import com.example.pace.domain.member.exception.MemberException;
+import com.example.pace.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class MemberCommandService {
+    private final MemberRepository memberRepository;
+
+    // 회원 탈퇴 로직
+    public void withdrawalMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        member.updateRefreshToken(null);
+        memberRepository.deleteById(member.getId());
+    }
 }

--- a/src/main/java/com/example/pace/global/auth/JwtUtil.java
+++ b/src/main/java/com/example/pace/global/auth/JwtUtil.java
@@ -45,24 +45,16 @@ public class JwtUtil {
     // 토큰이 유효한지 검증
     public boolean validateToken(String token) {
         try {
-            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
 
             return true;
         } catch (Exception e) {
             log.warn("Invalid JWT token: {}", token);
             return false;
         }
-    }
-
-    // 토큰에서 memberId를 추출
-    public Long getMemberIdFromToken(String token) {
-        Claims claims = Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
-
-        return Long.parseLong(claims.getSubject());
     }
 
     // 토큰에서 클레임을 추출하는 메서드
@@ -86,6 +78,6 @@ public class JwtUtil {
 
     // 신규 회원용 임시 토큰 생성
     public String createTempToken(Long memberId) {
-        return createToken(memberId, tempExpiration, Role.ROLE_IMCOMPLETE_USER);
+        return createToken(memberId, tempExpiration, Role.ROLE_INCOMPLETE_USER);
     }
 }

--- a/src/main/java/com/example/pace/global/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/com/example/pace/global/auth/filter/JwtAuthFilter.java
@@ -2,6 +2,7 @@ package com.example.pace.global.auth.filter;
 
 import com.example.pace.global.auth.CustomUserDetailsService;
 import com.example.pace.global.auth.JwtUtil;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,7 +39,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             token = authHeader.replace("Bearer ", "");
 
             try {
-                memberId = jwtUtil.getMemberIdFromToken(token);
+                Claims claims = jwtUtil.getClaimsFromToken(token);
+                memberId = Long.parseLong(claims.getSubject());
             } catch (Exception e) {
                 // 해당 예외는 JwtExceptionFilter에서 처리
                 logger.warn("잘못된 JWT token입니다: " + e.getMessage());


### PR DESCRIPTION
### 📌 관련 이슈
<!-- #이슈번호로 관련 이슈를 지정해주세요! ex) #12 --> 
Closed #14 
### ✨ 작업 내용 요약
<!-- 이번 PR에서 무엇을 변경했는지 간단히 적어주세요! -->
회원 로그아웃 기능과 탈퇴 기능을 만들었습니다.
### 🛠️ 주요 변경 사항
<!-- 변경 사항을 좀 더 구체적으로 작성해주세요! -->
- 로그아웃/탈퇴 시 데이터베이스에 저장된 refresh token을 무효화 하는 작업을 통해 토큰 재발급을 차단하였습니다.
- soft delete를 적용하여 회원 데이터를 비활성화 시켰습니다(is_active = false)
- 로그아웃 api 경로를 수정했습니다. /api/v1/auth/logout -> /api/v1/member/logout
### 📚 체크리스트
- [x] 팀 컨벤션에 맞는 커밋 메시지를 작성했나요?
- [x] 로컬 환경에서 정상 작동하는지 확인했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?

### 📸 테스트 결과 사진
<!-- 스웨거나 포스트맨 등을 통해 응답 결과 확인 캡쳐본을 넣어주세요! -->
<img width="1447" height="755" alt="image" src="https://github.com/user-attachments/assets/2f514c19-a829-4989-97df-11272d8c8a3b" />

### 🗣️ 리뷰어에게(선택)
<!-- 특히 꼼꼼히 봐주었으면 하는 부분이나 질문을 적어주세요! -->
