### PR TITLE
feat: 기간별 일정 목록조회 api 구현

### DIFF
--- a/src/main/java/com/example/pace/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/pace/domain/schedule/controller/ScheduleController.java
@@ -7,9 +7,8 @@ import com.example.pace.global.apiPayload.ApiResponse;
 import com.example.pace.global.apiPayload.code.GeneralSuccessCode;
 import com.example.pace.global.auth.CustomUserDetails;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,7 +50,7 @@ public class ScheduleController implements ScheduleControllerDocs {
     //일정 목록조회 API
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ScheduleResDto>>> getScheduleList(
+    public ResponseEntity<ApiResponse<Slice<ScheduleResDto>>> getScheduleList(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd")LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")LocalDate endDate,
@@ -60,7 +59,7 @@ public class ScheduleController implements ScheduleControllerDocs {
     ){
         Long memberId = customUserDetails.member().getId();
         LocalDate maxSearchDate = (endDate != null) ? endDate : LocalDate.of(9999, 12, 31);
-        List<ScheduleResDto> responseDto = scheduleService.getScheduleList(memberId, startDate, maxSearchDate, lastDate, lastId);
+        Slice<ScheduleResDto> responseDto = scheduleService.getScheduleList(memberId, startDate, maxSearchDate, lastDate, lastId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, responseDto));

--- a/src/main/java/com/example/pace/domain/schedule/controller/ScheduleControllerDocs.java
+++ b/src/main/java/com/example/pace/domain/schedule/controller/ScheduleControllerDocs.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
-import java.util.List;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -26,7 +26,7 @@ public interface ScheduleControllerDocs {
             @PathVariable Long scheduleId);
 
     @Operation(summary = "일정 목록 조회")
-    ResponseEntity<ApiResponse<List<ScheduleResDto>>> getScheduleList(
+    ResponseEntity<ApiResponse<Slice<ScheduleResDto>>> getScheduleList(
             CustomUserDetails customUserDetails,
             LocalDate startDate,
             LocalDate maxSearchDate,

--- a/src/main/java/com/example/pace/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/Schedule.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
@@ -60,6 +61,7 @@ public class Schedule extends BaseEntity { // BaseEntity: created_at, updated_at
     private Place place;
 
     @Builder.Default
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "schedule",cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reminder> reminderList = new ArrayList<>();
 

--- a/src/main/java/com/example/pace/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/pace/domain/schedule/repository/ScheduleRepository.java
@@ -3,8 +3,8 @@ package com.example.pace.domain.schedule.repository;
 import com.example.pace.domain.member.entity.Member;
 import com.example.pace.domain.schedule.entity.Schedule;
 import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,19 +14,16 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
      * 멤버의 일정 목록을 커서 기반 무한 스크롤로 조회
      * 마지막 조회 날짜보다 크거나 날짜가 같으면 ID가 큰 일정부터 조회
      */
-    @Query("select distinct s from Schedule s " +
+    @Query("select s from Schedule s " +
             "left join fetch s.place " +
-            "left join fetch s.reminderList " +
             "where s.member.id = :memberId " +
             "and (s.startDate > :lastDate or (s.startDate = :lastDate and s.id > :lastId)) " +
             "and s.startDate <= :endDate " +
             "order by s.startDate asc, s.id asc")
-    List<Schedule> findAllByMemberAndDateRange(
+    Slice<Schedule> findAllByMemberAndDateRange(
             @Param("memberId") Long memberId,
             @Param("lastDate") LocalDate lastDate,
             @Param("lastId") Long lastId,
             @Param("endDate") LocalDate endDate,
             Pageable pageable);
-
-    Long member(Member member);
 }

--- a/src/main/java/com/example/pace/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/pace/domain/schedule/service/ScheduleService.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,7 +78,7 @@ public class  ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public List<ScheduleResDto> getScheduleList(
+    public Slice<ScheduleResDto> getScheduleList(
             Long memberId,
             LocalDate startDate,
             LocalDate maxSearchDate,
@@ -87,10 +88,8 @@ public class  ScheduleService {
         LocalDate cursorDate = (lastDate != null) ? lastDate : startDate;
         Long cursorId = (lastId != null) ? lastId : 0L;
         Pageable pageable = PageRequest.of(0, 20);
-        List<Schedule> schedules = scheduleRepository.findAllByMemberAndDateRange(memberId,cursorDate, cursorId, maxSearchDate, pageable);
+        Slice<Schedule> schedules = scheduleRepository.findAllByMemberAndDateRange(memberId,cursorDate, cursorId, maxSearchDate, pageable);
 
-        return schedules.stream()
-                .map(ScheduleResDtoConverter::toScheduleResDto)
-                .toList();
+        return schedules.map(ScheduleResDtoConverter::toScheduleResDto);
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- #이슈번호로 관련 이슈를 지정해주세요! ex) #12 --> 
#24 

### ✨ 작업 내용 요약
<!-- 이번 PR에서 무엇을 변경했는지 간단히 적어주세요! -->
- 기간별 일정 목록조회 api 구현
- 시작날짜와 끝날짜 같게 설정하면 하루 일정 목록조회
### 🛠️ 주요 변경 사항
<!-- 변경 사항을 좀 더 구체적으로 작성해주세요! -->
- 커서 기반 페이징을 활용했습니다.
- 일정 목록 조회 시 연관된 장소와 알림목록을 fetch join으로 한 번에 가져오도록 쿼리를 최적화했습니다.

### 📚 체크리스트
- [x] 팀 컨벤션에 맞는 커밋 메시지를 작성했나요?
- [x] 로컬 환경에서 정상 작동하는지 확인했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?

### 📸 테스트 결과 사진
<!-- 스웨거나 포스트맨 등을 통해 응답 결과 확인 캡쳐본을 넣어주세요! -->
<img width="1149" height="766" alt="스크린샷 2026-01-22 오후 9 26 37" src="https://github.com/user-attachments/assets/70e6a7d9-7566-44d6-af4d-8463961e7216" />


### 🗣️ 리뷰어에게(선택)
<!-- 특히 꼼꼼히 봐주었으면 하는 부분이나 질문을 적어주세요! -->
