### PR TITLE
feat: 장소 저장 API 기능 구현

### DIFF
--- a/src/main/java/com/example/pace/domain/member/controller/SavedPlaceController.java
+++ b/src/main/java/com/example/pace/domain/member/controller/SavedPlaceController.java
@@ -1,0 +1,40 @@
+package com.example.pace.domain.member.controller;
+
+import com.example.pace.domain.member.dto.request.SavedPlaceReqDTO;
+import com.example.pace.domain.member.dto.response.SavedPlaceResDTO;
+import com.example.pace.domain.member.exception.MemberSuccessCode;
+import com.example.pace.domain.member.service.SavedPlaceCommandService;
+import com.example.pace.global.apiPayload.ApiResponse;
+import com.example.pace.global.auth.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/places")
+public class SavedPlaceController implements SavedPlaceControllerDocs {
+    private final SavedPlaceCommandService savedPlaceCommandService;
+
+    @Override
+    @PostMapping("/saved")
+    public ResponseEntity<ApiResponse<SavedPlaceResDTO.PlaceDTO>> savePlace(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid SavedPlaceReqDTO.SavedPlaceDTO request
+    ) {
+        Long memberId = userDetails.member().getId();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(
+                        ApiResponse.onSuccess(
+                                MemberSuccessCode.SAVED_PLACE_CREATE_OK,
+                                savedPlaceCommandService.savePlace(memberId, request)
+                        )
+                );
+    }
+}

--- a/src/main/java/com/example/pace/domain/member/controller/SavedPlaceControllerDocs.java
+++ b/src/main/java/com/example/pace/domain/member/controller/SavedPlaceControllerDocs.java
@@ -1,0 +1,48 @@
+package com.example.pace.domain.member.controller;
+
+import com.example.pace.domain.member.dto.request.SavedPlaceReqDTO;
+import com.example.pace.domain.member.dto.response.SavedPlaceResDTO;
+import com.example.pace.global.apiPayload.ApiResponse;
+import com.example.pace.global.auth.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Saved Place API", description = "장소 저장(즐겨찾기) 관련 API")
+public interface SavedPlaceControllerDocs {
+
+    @Operation(summary = "장소 저장 API", description = "사용자가 특정 장소를 저장(즐겨찾기)합니다. 같은 그룹 내 중복된 장소는 저장이 불가합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "장소 저장 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(name = "성공 예시", value = "{\"isSuccess\":true, \"code\":\"MEMBER201_1\", \"message\":\"장소 저장 성공\", \"result\":{\"savedPlaceId\":\"1\", \"groupName\":\"맛집\", \"placeName\":\"스타벅스 강남역점\", \"placeId\":\"21160611\", \"createdAt\":\"2024-01-21 16:00\"}}")
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "중복된 장소 저장 시도",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(name = "중복 에러 예시", value = "{\"isSuccess\":false, \"code\":\"MEMBER400_1\", \"message\":\"이미 해당 그룹에 저장된 장소입니다.\", \"result\":null}")
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(name = "인증 에러 예시", value = "{\"isSuccess\":false, \"code\":\"COMMON401\", \"message\":\"인증이 필요합니다.\", \"result\":null}")
+                    )
+            )
+    })
+    ResponseEntity<ApiResponse<SavedPlaceResDTO.PlaceDTO>> savePlace(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @RequestBody SavedPlaceReqDTO.SavedPlaceDTO request
+    );
+}

--- a/src/main/java/com/example/pace/domain/member/converter/SavedPlaceConverter.java
+++ b/src/main/java/com/example/pace/domain/member/converter/SavedPlaceConverter.java
@@ -1,0 +1,32 @@
+package com.example.pace.domain.member.converter;
+
+import com.example.pace.domain.member.dto.request.SavedPlaceReqDTO;
+import com.example.pace.domain.member.dto.response.SavedPlaceResDTO;
+import com.example.pace.domain.member.entity.Member;
+import com.example.pace.domain.member.entity.SavedPlace;
+import java.time.format.DateTimeFormatter;
+
+public class SavedPlaceConverter {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public static SavedPlace toEntity(
+            SavedPlaceReqDTO.SavedPlaceDTO dto,
+            Member member
+    ) {
+        return SavedPlace.builder()
+                .placeId(dto.getPlaceId())
+                .groupName(dto.getGroupName())
+                .placeName(dto.getPlaceName())
+                .member(member)
+                .build();
+    }
+
+    public static SavedPlaceResDTO.PlaceDTO toPlaceDTO(SavedPlace savedPlace) {
+        return SavedPlaceResDTO.PlaceDTO.builder()
+                .placeId(savedPlace.getPlaceId())
+                .groupName(savedPlace.getGroupName())
+                .placeName(savedPlace.getPlaceName())
+                .createdAt(savedPlace.getCreatedAt().format(formatter))
+                .build();
+    }
+}

--- a/src/main/java/com/example/pace/domain/member/dto/request/SavedPlaceReqDTO.java
+++ b/src/main/java/com/example/pace/domain/member/dto/request/SavedPlaceReqDTO.java
@@ -1,0 +1,20 @@
+package com.example.pace.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SavedPlaceReqDTO {
+    @Getter
+    @NoArgsConstructor
+    public static class SavedPlaceDTO {
+        @NotBlank(message = "장소 이름은 필수입니다.")
+        private String placeName;
+
+        @NotBlank(message = "장소 그룹명은 필수입니다.")
+        private String groupName;
+
+        @NotBlank(message = "장소id는 필수입니다.")
+        private String placeId;
+    }
+}

--- a/src/main/java/com/example/pace/domain/member/dto/response/SavedPlaceResDTO.java
+++ b/src/main/java/com/example/pace/domain/member/dto/response/SavedPlaceResDTO.java
@@ -1,0 +1,20 @@
+package com.example.pace.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SavedPlaceResDTO {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PlaceDTO {
+        private String savedPlaceId;
+        private String groupName;
+        private String placeName;
+        private String placeId;
+        private String createdAt;
+    }
+}

--- a/src/main/java/com/example/pace/domain/member/entity/SavedPlace.java
+++ b/src/main/java/com/example/pace/domain/member/entity/SavedPlace.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,20 +29,29 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "saved_place")
+@Table(
+        name = "saved_place",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_saved_place_member_group",
+                        columnNames = {"member_id", "group_name"} // 하나의 유저가 같은 이름의 그룹을 만들지 못하게 설정
+                ),
+                @UniqueConstraint(
+                        name = "uk_saved_place_member_place",
+                        columnNames = {"member_id", "place_id", "group_name"} // 하나의 유저가 같은 그룹 내에 같은 장소를 저장하지 못하게 설정
+                )
+        }
+)
 public class SavedPlace extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "place_name", nullable = false)
-    private String placeName;
+    private String placeName; // 장소명
 
-    @Column(name = "place_lat", nullable = false, precision = 18, scale = 10)
-    private BigDecimal placeLat;
-
-    @Column(name = "place_lng", nullable = false, precision = 18, scale = 10)
-    private BigDecimal placeLng;
+    @Column(name = "group_name", nullable = false)
+    private String groupName; // 회의 때 확인됐던 그룹명
 
     @Column(name = "place_id")
     private String placeId; // 고유 장소 ID (예: 구글 플레이스 ID)

--- a/src/main/java/com/example/pace/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/pace/domain/member/exception/MemberErrorCode.java
@@ -14,8 +14,9 @@ public enum MemberErrorCode implements BaseErrorCode {
     MEMBER_NOT_ACTIVE(HttpStatus.UNAUTHORIZED,
             "탈퇴한 회원입니다.",
             "MEMBER401_1"),
-
-    ;
+    SAVED_PLACE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,
+            "이미 해당 그룹 내에 동일한 장소가 있습니다.",
+            "MEMBER404_2");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/pace/domain/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/example/pace/domain/member/exception/MemberSuccessCode.java
@@ -12,6 +12,11 @@ public enum MemberSuccessCode implements BaseSuccessCode {
             "성공적으로 로그인에 성공하였습니다.",
             "MEMBER200_1"
     ),
+    SAVED_PLACE_CREATE_OK(
+            HttpStatus.OK,
+            "장소가 성공적으로 저장되었습니다.",
+            "MEMBER201_1"
+    ),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/pace/domain/member/repository/SavedPlaceRepository.java
+++ b/src/main/java/com/example/pace/domain/member/repository/SavedPlaceRepository.java
@@ -1,4 +1,9 @@
 package com.example.pace.domain.member.repository;
 
-public interface SavedPlaceRepository {
+import com.example.pace.domain.member.entity.SavedPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SavedPlaceRepository extends JpaRepository<SavedPlace, Long>, SavedPlaceRepositoryCustom {
 }

--- a/src/main/java/com/example/pace/domain/member/repository/SavedPlaceRepositoryCustom.java
+++ b/src/main/java/com/example/pace/domain/member/repository/SavedPlaceRepositoryCustom.java
@@ -1,0 +1,6 @@
+package com.example.pace.domain.member.repository;
+
+public interface SavedPlaceRepositoryCustom {
+    // 해당 유저의 같은 그룹에 같은 장소가 이미 있는지 확인하는 메서드
+    boolean isPlaceSavedInGroup(Long memberId, String placeId, String groupName);
+}

--- a/src/main/java/com/example/pace/domain/member/repository/SavedPlaceRepositoryImpl.java
+++ b/src/main/java/com/example/pace/domain/member/repository/SavedPlaceRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.example.pace.domain.member.repository;
+
+import static com.example.pace.domain.member.entity.QSavedPlace.savedPlace;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SavedPlaceRepositoryImpl implements SavedPlaceRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean isPlaceSavedInGroup(Long memberId, String placeId, String groupName) {
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(savedPlace)
+                .where(
+                        savedPlace.member.id.eq(memberId),
+                        savedPlace.placeId.eq(placeId),
+                        savedPlace.groupName.eq(groupName)
+                )
+                .fetchFirst(); // limit 1과 동일(결과가 없으면 null 반환)
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/com/example/pace/domain/member/service/SavedPlaceCommandService.java
+++ b/src/main/java/com/example/pace/domain/member/service/SavedPlaceCommandService.java
@@ -1,0 +1,37 @@
+package com.example.pace.domain.member.service;
+
+import com.example.pace.domain.member.converter.SavedPlaceConverter;
+import com.example.pace.domain.member.dto.request.SavedPlaceReqDTO;
+import com.example.pace.domain.member.dto.response.SavedPlaceResDTO;
+import com.example.pace.domain.member.entity.Member;
+import com.example.pace.domain.member.entity.SavedPlace;
+import com.example.pace.domain.member.exception.MemberErrorCode;
+import com.example.pace.domain.member.exception.MemberException;
+import com.example.pace.domain.member.repository.MemberRepository;
+import com.example.pace.domain.member.repository.SavedPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SavedPlaceCommandService {
+    private final SavedPlaceRepository savedPlaceRepository;
+    private final MemberRepository memberRepository;
+
+    // 장소 저장
+    public SavedPlaceResDTO.PlaceDTO savePlace(Long memberId, SavedPlaceReqDTO.SavedPlaceDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (savedPlaceRepository.isPlaceSavedInGroup(memberId, request.getPlaceId(), request.getGroupName())) {
+            throw new MemberException(MemberErrorCode.SAVED_PLACE_ALREADY_EXISTS);
+        }
+
+        SavedPlace savedPlace = SavedPlaceConverter.toEntity(request, member);
+        SavedPlace saved = savedPlaceRepository.save(savedPlace);
+
+        return SavedPlaceConverter.toPlaceDTO(saved);
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
<!-- #이슈번호로 관련 이슈를 지정해주세요! ex) #12 --> 
close #37 
### ✨ 작업 내용 요약
<!-- 이번 PR에서 무엇을 변경했는지 간단히 적어주세요! -->
- 장소를 저장하는 API 기능을 제작하였습니다.
### 🛠️ 주요 변경 사항
<!-- 변경 사항을 좀 더 구체적으로 작성해주세요! -->
- 장소명, 그룹명, 장소id 정보를 통해 장소를 저장할 수 있습니다.
- QueryDsl을 활용하여 중복 체크 로직을 구현하였습니다.
### 📚 체크리스트
- [x] 팀 컨벤션에 맞는 커밋 메시지를 작성했나요?
- [x] 로컬 환경에서 정상 작동하는지 확인했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?

### 📸 테스트 결과 사진
<!-- 스웨거나 포스트맨 등을 통해 응답 결과 확인 캡쳐본을 넣어주세요! -->
- 장소 저장을 성공했을 때
<img width="1417" height="584" alt="image" src="https://github.com/user-attachments/assets/36c80559-7561-404a-9c9e-fe2406aad284" />
- 같은 그룹 내에 같은 장소가 중복으로 저장되려고 할 때
<img width="1410" height="515" alt="image" src="https://github.com/user-attachments/assets/1addb816-1bab-462e-a06c-1dab9d7f91ca" />

### 🗣️ 리뷰어에게(선택)
<!-- 특히 꼼꼼히 봐주었으면 하는 부분이나 질문을 적어주세요! -->