### PR TITLE
refactor: 인덱스를 추가함으로써 조회 성능 향상 완료

### DIFF
--- a/src/main/java/com/example/pace/domain/member/entity/Member.java
+++ b/src/main/java/com/example/pace/domain/member/entity/Member.java
@@ -36,7 +36,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Table(uniqueConstraints = {
         @UniqueConstraint(
                 name = "social_provider_id_unique",
-                columnNames = {"socialProvider", "socialId"}
+                columnNames = {"social_provider", "social_id"}
         )
 })
 @SQLDelete(sql = "UPDATE member SET is_active = false WHERE id = ?") // delete()시 hard delete 하는 것이 아닌 soft delete를 진행

--- a/src/main/java/com/example/pace/domain/member/entity/MemberTerms.java
+++ b/src/main/java/com/example/pace/domain/member/entity/MemberTerms.java
@@ -1,4 +1,0 @@
-package com.example.pace.domain.member.entity;
-
-public class MemberTerms {
-}

--- a/src/main/java/com/example/pace/domain/member/entity/PlaceGroup.java
+++ b/src/main/java/com/example/pace/domain/member/entity/PlaceGroup.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -34,6 +35,10 @@ import lombok.Setter;
                         name = "uk_place_group_member_group_name",
                         columnNames = {"member_id", "group_name"}
                 )
+        },
+        // 회원별 그룹 목록 조회를 위한 인덱스 칼럼 지정
+        indexes = {
+                @Index(name = "idx_place_group_member", columnList = "member_id")
         }
 )
 public class PlaceGroup extends BaseEntity {

--- a/src/main/java/com/example/pace/domain/member/entity/ReminderTime.java
+++ b/src/main/java/com/example/pace/domain/member/entity/ReminderTime.java
@@ -9,12 +9,19 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Table(
+        name = "reminder_time",
+        indexes = {
+                // 세팅의 반복 시간을 조회하기 위한 인덱스 칼럼 지정
+                @Index(name = "idx_reminder_time_setting", columnList = "setting_id")
+        }
+)
 public class ReminderTime {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "setting_id", nullable = false)
     private Setting setting;
@@ -25,8 +32,4 @@ public class ReminderTime {
     @Enumerated(EnumType.STRING)
     @Column(name = "alarm_type", nullable = false, length = 20)
     private AlarmType alarmType;
-
-    public void setSetting(Setting setting) {
-        this.setting = setting;
-    }
 }

--- a/src/main/java/com/example/pace/domain/member/entity/SavedPlace.java
+++ b/src/main/java/com/example/pace/domain/member/entity/SavedPlace.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,6 +26,10 @@ import lombok.Setter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(
         name = "saved_place",
+        indexes = {
+                // 그룹 내 장소 조회 및 정렬 성능을 고려한 인덱스 칼럼 지정
+                @Index(name = "idx_saved_place_member_group_date", columnList = "member_id, place_group_id, created_at")
+        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_saved_place_member_place",

--- a/src/main/java/com/example/pace/domain/member/entity/Setting.java
+++ b/src/main/java/com/example/pace/domain/member/entity/Setting.java
@@ -27,7 +27,7 @@ public class Setting extends BaseEntity {
     private Long settingId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
 
     // 알림 권한 허용 여부
@@ -78,11 +78,21 @@ public class Setting extends BaseEntity {
             Boolean isReminderActive,
             CalendarType calendarType
     ) {
-        if (earlyArrivalTime != null) this.earlyArrivalTime = earlyArrivalTime;
-        if (isNotiEnabled != null) this.isNotiEnabled = isNotiEnabled;
-        if (isLocEnabled != null) this.isLocEnabled = isLocEnabled;
-        if (isReminderActive != null) this.isReminderActive = isReminderActive;
-        if (calendarType != null) this.calendarType = calendarType;
+        if (earlyArrivalTime != null) {
+            this.earlyArrivalTime = earlyArrivalTime;
+        }
+        if (isNotiEnabled != null) {
+            this.isNotiEnabled = isNotiEnabled;
+        }
+        if (isLocEnabled != null) {
+            this.isLocEnabled = isLocEnabled;
+        }
+        if (isReminderActive != null) {
+            this.isReminderActive = isReminderActive;
+        }
+        if (calendarType != null) {
+            this.calendarType = calendarType;
+        }
     }
 
     // Lombok Boolean Getter 우회

--- a/src/main/java/com/example/pace/domain/schedule/entity/Place.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/Place.java
@@ -1,6 +1,5 @@
 package com.example.pace.domain.schedule.entity;
 
-import com.example.pace.domain.member.entity.Member;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
@@ -12,20 +11,16 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Place {
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "schedule_id", nullable = false)
+    @JoinColumn(name = "schedule_id", nullable = false, unique = true)
     private Schedule schedule;
 
     private String targetName;
     private BigDecimal targetLat;
     private BigDecimal targetLng;
-
-    public void setSchedule(Schedule schedule) {
-        this.schedule = schedule;
-
-    }
 }

--- a/src/main/java/com/example/pace/domain/schedule/entity/Reminder.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/Reminder.java
@@ -12,7 +12,13 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "reminder")
+@Table(
+        name = "reminder",
+        indexes = {
+                // 일정으로 알림 관련 정보를 조회하기 위한 인덱스 칼럼 지정
+                @Index(name = "idx_reminder_schedule", columnList = "schedule_id")
+        }
+)
 public class Reminder extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/pace/domain/schedule/entity/RepeatRule.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/RepeatRule.java
@@ -23,7 +23,6 @@ import lombok.Setter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RepeatRule extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/pace/domain/schedule/entity/Route.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/Route.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
@@ -30,9 +31,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "route")
-
 public class Route extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -72,7 +71,7 @@ public class Route extends BaseEntity {
     private LocalDateTime departureTime; //출발 예정 시간
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "schedule_id")
+    @JoinColumn(name = "schedule_id", unique = true)
     private Schedule schedule;
 
     @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/pace/domain/schedule/entity/RouteDetail.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/RouteDetail.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -26,7 +27,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "route_detail")
+@Table(
+        name = "route_detail",
+        indexes = {
+                // 특정 경로의 상세 정보를 순서대로 조회할 때 사용하기 위한 인덱스 칼럼 지정
+                @Index(name = "idx_route_detail_route_sequence", columnList = "route_id, sequence")
+        }
+)
 public class RouteDetail extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/pace/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/pace/domain/schedule/entity/Schedule.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -32,7 +33,15 @@ import org.hibernate.annotations.BatchSize;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "schedule")
+@Table(
+        name = "schedule",
+        indexes = {
+                // 커서 페이징 최적화 인덱스 칼럼 지정
+                @Index(name = "idx_schedule_member_date_id", columnList = "member_id, start_date, id"),
+                // 반복 일정 조회를 위한 인덱스 칼럼 지정
+                @Index(name = "idx_schedule_repeat_group", columnList = "repeat_group_id")
+        }
+)
 public class Schedule extends BaseEntity { // BaseEntity: created_at, updated_at
 
     @Id
@@ -45,13 +54,19 @@ public class Schedule extends BaseEntity { // BaseEntity: created_at, updated_at
 
     @Column(nullable = false)
     private String title;
-    @Column(nullable = false)
+    @Column(name = "is_all_day", nullable = false)
     private Boolean isAllDay;
+    @Column(name = "start_date")
     private LocalDate startDate;
+    @Column(name = "end_date")
     private LocalDate endDate;
+    @Column(name = "start_time")
     private LocalTime startTime;
+    @Column(name = "end_time")
     private LocalTime endTime;
+    @Column(name = "is_repeat")
     private Boolean isRepeat;
+    @Column(name = "repeat_group_id")
     private String repeatGroupId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -85,15 +100,32 @@ public class Schedule extends BaseEntity { // BaseEntity: created_at, updated_at
         this.place = place;
         place.setSchedule(this);
     }
+
     public void updateGeneralInfo(ScheduleUpdateReqDto dto) {
-        if (dto.getTitle() != null) this.title = dto.getTitle();
-        if (dto.getMemo() != null) this.memo = dto.getMemo();
-        if (dto.getStartDate() != null) this.startDate = dto.getStartDate();
-        if (dto.getEndDate() != null) this.endDate = dto.getEndDate();
-        if (dto.getStartTime() != null) this.startTime = dto.getStartTime();
-        if (dto.getEndTime() != null) this.endTime = dto.getEndTime();
-        if (dto.getIsAllDay() != null) this.isAllDay = dto.getIsAllDay();
-        if (dto.getIsPathIncluded() != null) this.isPathIncluded = dto.getIsPathIncluded();
+        if (dto.getTitle() != null) {
+            this.title = dto.getTitle();
+        }
+        if (dto.getMemo() != null) {
+            this.memo = dto.getMemo();
+        }
+        if (dto.getStartDate() != null) {
+            this.startDate = dto.getStartDate();
+        }
+        if (dto.getEndDate() != null) {
+            this.endDate = dto.getEndDate();
+        }
+        if (dto.getStartTime() != null) {
+            this.startTime = dto.getStartTime();
+        }
+        if (dto.getEndTime() != null) {
+            this.endTime = dto.getEndTime();
+        }
+        if (dto.getIsAllDay() != null) {
+            this.isAllDay = dto.getIsAllDay();
+        }
+        if (dto.getIsPathIncluded() != null) {
+            this.isPathIncluded = dto.getIsPathIncluded();
+        }
     }
 
     public void updateDetailedInfo(ScheduleUpdateReqDto dto) {
@@ -133,7 +165,9 @@ public class Schedule extends BaseEntity { // BaseEntity: created_at, updated_at
 
     @PrePersist
     public void prePersist() {
-        if (isPathIncluded == null) isPathIncluded = false;
+        if (isPathIncluded == null) {
+            isPathIncluded = false;
+        }
     }
 
 }

--- a/src/main/java/com/example/pace/domain/schedule/repository/RouteDetailRepository.java
+++ b/src/main/java/com/example/pace/domain/schedule/repository/RouteDetailRepository.java
@@ -1,7 +1,0 @@
-package com.example.pace.domain.schedule.repository;
-
-import com.example.pace.domain.schedule.entity.RouteDetail;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RouteDetailRepository extends JpaRepository<RouteDetail, Long> {
-}

--- a/src/main/java/com/example/pace/domain/transit/entity/BusInfo.java
+++ b/src/main/java/com/example/pace/domain/transit/entity/BusInfo.java
@@ -19,10 +19,13 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "bus_info", indexes = {
-        @Index(name = "idx_bus_line_name", columnList = "line_name"), // 노선 번호로 검색 최적화
-        @Index(name = "idx_bus_line_sequence", columnList = "line_name, sequence") // 노선 내 순서 정렬 최적화
-})
+@Table(
+        name = "bus_info",
+        indexes = {
+                @Index(name = "idx_bus_line_name", columnList = "line_name"), // 노선 번호로 검색 최적화
+                @Index(name = "idx_bus_line_sequence", columnList = "line_name, sequence") // 노선 내 순서 정렬 최적화
+        }
+)
 public class BusInfo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- #이슈번호로 관련 이슈를 지정해주세요! ex) #12 --> 
Closes #113 
## ✨ 작업 내용 요약
<!-- 이번 PR에서 무엇을 변경했는지 간단히 적어주세요! -->
- 조회 성능 최적화를 위한 인덱스 설정을 하였습니다.
## 🛠️ 주요 변경 사항
<!-- 변경 사항을 좀 더 구체적으로 작성해주세요! -->
- 각 엔티티별로 조회가 잦은 칼럼들에 대해 인덱스를 걸어 조회 성능을 크게 향상 시켰습니다.
- 기존 1:1 관계 매핑 필드들에서 unique = true 속성이 걸려있지 않음을 확인하고 이를 수정했습니다.
## 📚 체크리스트
- [x] 팀 컨벤션에 맞는 커밋 메시지를 작성했나요?
- [x] 로컬 환경에서 정상 작동하는지 확인했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?

### 📸 테스트 결과 사진
<!-- 스웨거나 포스트맨 등을 통해 응답 결과 확인 캡쳐본을 넣어주세요! -->
#### 데이터가 10만건이 있을 때 조회 성능 비교(데이터가 많아질수록 성능 차이도 심해짐)
1. 일정 조회 시 인덱스가 걸려있을 때와 걸려있지 않을 때의 조회 시간 차이 (약 15.5배)
<img width="1046" height="35" alt="image" src="https://github.com/user-attachments/assets/218cc713-1ae9-4520-9085-8c4aaf53f3cb" />

2. 특정 그룹의 저장된 장소를 최신순으로 정렬하여 조회 시 인덱스가 걸려있을 때와 걸려있지 않을 때의 조회 시간 차이 (약 16.6배)
<img width="1036" height="34" alt="image" src="https://github.com/user-attachments/assets/05353dca-36eb-4e0f-9512-1104373e946d" />

3. 상세 경로의 순번을 오름차순 정렬하여 조회 시 인덱스가 걸려있을 때와 걸려있지 않을 때의 조회 시간 차이 (약 607.7배) 
<img width="885" height="34" alt="image" src="https://github.com/user-attachments/assets/fd4d98bb-243c-48bf-90b3-0a8e1b534300" />

### 🗣️ 리뷰어에게(선택)
<!-- 특히 꼼꼼히 봐주었으면 하는 부분이나 질문을 적어주세요! -->
