### PR TITLE
refactor: calendarType 제거 및 calendarId(Long) 기반으로 온보딩/세팅 로직 변경

### DIFF
--- a/src/main/java/com/example/pace/domain/member/converter/SettingConverter.java
+++ b/src/main/java/com/example/pace/domain/member/converter/SettingConverter.java
@@ -51,7 +51,7 @@ public class SettingConverter {
                 .isNotiEnabled(setting.isNotiEnabled())
                 .isLocEnabled(setting.isLocEnabled())
                 .isReminderActive(setting.isReminderActive())
-                .calendarType(setting.getCalendarType())
+                .calendarId(setting.getCalendarId())
                 .alarms(alarms)
                 .createdAt(setting.getCreatedAt())
                 .updatedAt(setting.getUpdatedAt())

--- a/src/main/java/com/example/pace/domain/member/dto/request/OnboardingReqDTO.java
+++ b/src/main/java/com/example/pace/domain/member/dto/request/OnboardingReqDTO.java
@@ -1,7 +1,6 @@
 package com.example.pace.domain.member.dto.request;
 
 import com.example.pace.domain.member.enums.AlarmType;
-import com.example.pace.domain.member.enums.CalendarType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -29,10 +28,9 @@ public record OnboardingReqDTO (
 
         @Min(0) @Max(60) Integer earlyArrivalTime,   // 정책에 맞게 1시간으로 상한 조절
 
-        @NotNull CalendarType calendarType,  // enum이면 enum으로 바꾸기
+        @NotNull String calendarId,
 
-        @Valid
-        List<AlarmConfig> alarms
+        @Valid List<AlarmConfig> alarms
 ){
     public record AlarmConfig(
             @NotNull AlarmType type,

--- a/src/main/java/com/example/pace/domain/member/dto/request/SettingUpdateRequestDTO.java
+++ b/src/main/java/com/example/pace/domain/member/dto/request/SettingUpdateRequestDTO.java
@@ -1,7 +1,6 @@
 package com.example.pace.domain.member.dto.request;
 
 import com.example.pace.domain.member.enums.AlarmType;
-import com.example.pace.domain.member.enums.CalendarType;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
@@ -23,7 +22,7 @@ public class SettingUpdateRequestDTO {
     private Boolean isReminderActive;
 
     // 캘린더 선택
-    private CalendarType calendarType;
+    private String calendarId;
 
     //alarms로 받기 위해
     private List<Alarm> alarms;

--- a/src/main/java/com/example/pace/domain/member/dto/response/SettingResponseDTO.java
+++ b/src/main/java/com/example/pace/domain/member/dto/response/SettingResponseDTO.java
@@ -2,7 +2,6 @@ package com.example.pace.domain.member.dto.response;
 
 import com.example.pace.domain.member.converter.SettingConverter;
 import com.example.pace.domain.member.enums.AlarmType;
-import com.example.pace.domain.member.enums.CalendarType;
 import com.example.pace.domain.member.entity.Setting;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -25,7 +24,7 @@ public class SettingResponseDTO {
     private Boolean isLocEnabled;
 
     private Boolean isReminderActive;
-    private CalendarType calendarType;
+    private Long calendarId;
     private List<AlarmConfig> alarms;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/pace/domain/member/entity/Setting.java
+++ b/src/main/java/com/example/pace/domain/member/entity/Setting.java
@@ -1,7 +1,6 @@
 package com.example.pace.domain.member.entity;
 
 import com.example.pace.domain.member.enums.AlarmType;
-import com.example.pace.domain.member.enums.CalendarType;
 import com.example.pace.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -48,9 +47,8 @@ public class Setting extends BaseEntity {
     private Boolean isReminderActive;
 
     // 캘린더 선택
-    @Enumerated(EnumType.STRING)
-    @Column(name = "calendar_type", nullable = false, length = 30)
-    private CalendarType calendarType;
+    @Column(name = "calendar_id", nullable = true)
+    private Long calendarId;
 
     @OneToMany(mappedBy = "setting", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -76,7 +74,7 @@ public class Setting extends BaseEntity {
             Boolean isNotiEnabled,
             Boolean isLocEnabled,
             Boolean isReminderActive,
-            CalendarType calendarType
+            Long calendarId
     ) {
         if (earlyArrivalTime != null) {
             this.earlyArrivalTime = earlyArrivalTime;
@@ -90,8 +88,8 @@ public class Setting extends BaseEntity {
         if (isReminderActive != null) {
             this.isReminderActive = isReminderActive;
         }
-        if (calendarType != null) {
-            this.calendarType = calendarType;
+        if (calendarId != null) {
+            this.calendarId = calendarId;
         }
     }
 

--- a/src/main/java/com/example/pace/domain/member/enums/CalendarType.java
+++ b/src/main/java/com/example/pace/domain/member/enums/CalendarType.java
@@ -1,7 +1,0 @@
-package com.example.pace.domain.member.enums;
-
-public enum CalendarType {
-    GOOGLE,
-    SAMSUNG,
-    LOCAL //핸드폰 번호?
-}

--- a/src/main/java/com/example/pace/domain/member/exception/code/OnboardingErrorCode.java
+++ b/src/main/java/com/example/pace/domain/member/exception/code/OnboardingErrorCode.java
@@ -18,7 +18,8 @@ public enum OnboardingErrorCode implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다.", "ONBOARDING404_3"),
     INVALID_EARLY_ARRIVAL_TIME(HttpStatus.BAD_REQUEST, "미리 도착 시간 값이 유효하지 않습니다.", "ONBOARDING400_1"),
     TOO_MANY_ALARMS(HttpStatus.BAD_REQUEST, "알림 시간은 타입별 최대 5개까지 선택할 수 있습니다.", "ONBOARDING400_2"),
-    INVALID_ALARM_MINUTES(HttpStatus.BAD_REQUEST, "허용되지 않은 알림 시간이 포함되어 있습니다.", "ONBOARDING400_3");
+    INVALID_ALARM_MINUTES(HttpStatus.BAD_REQUEST, "허용되지 않은 알림 시간이 포함되어 있습니다.", "ONBOARDING400_3"),
+    INVALID_CALENDAR_ID(HttpStatus.BAD_REQUEST, "calendarId 형식이 올바르지 않습니다.", "SETTING400_3");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/pace/domain/member/exception/code/SettingErrorCode.java
+++ b/src/main/java/com/example/pace/domain/member/exception/code/SettingErrorCode.java
@@ -15,7 +15,9 @@ public enum SettingErrorCode implements BaseErrorCode {
     ONBOARDING_REQUIRED(HttpStatus.CONFLICT, "SETTING409_1", "온보딩 후에 가능합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "SETTING403_1", "접근 권한이 없습니다."),
     TOO_MANY_ALARMS(HttpStatus.BAD_REQUEST, "SETTING400_1", "알람은 타입별로 최대 5개까지 설정할 수 있습니다."),
-    INVALID_ALARM_MINUTES(HttpStatus.BAD_REQUEST, "SETTING400_2", "허용되지 않은 알람 시간 값이 포함되어 있습니다.");
+    INVALID_ALARM_MINUTES(HttpStatus.BAD_REQUEST, "SETTING400_2", "허용되지 않은 알람 시간 값이 포함되어 있습니다."),
+    INVALID_CALENDAR_ID(HttpStatus.BAD_REQUEST, "SETTING400_3", "calendarId 형식이 올바르지 않습니다."),
+    CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTING404_3", "존재하지 않는 캘린더입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/pace/domain/member/service/command/OnboardingCommandService.java
+++ b/src/main/java/com/example/pace/domain/member/service/command/OnboardingCommandService.java
@@ -59,13 +59,21 @@ public class OnboardingCommandService {
         // alarms 정규화:  항상 SCHEDULE/DEPARTURE 둘 다 포함시키기 (없으면 빈 리스트로)
         Map<AlarmType, List<Integer>> alarmMap = toValidatedAlarmMap(request.alarms());
 
+        Long calendarId;
+        try {
+            calendarId = Long.parseLong(request.calendarId());
+        } catch (NumberFormatException e) {
+            throw new OnboardingException(OnboardingErrorCode.INVALID_CALENDAR_ID);
+        }
+
+
         // setting 기본 값 업데이트 (온보딩에서 받는 값)
         setting.update(
                 earlyArrivalTime,   // Integer earlyArrivalTime
                 null,                         // isNotiEnabled: 온보딩에서 안 받으면 유지
                 null,                         // isLocEnabled: 온보딩에서 안 받으면 유지
                 request.isReminderActive(),
-                request.calendarType()
+                calendarId
         );
 
         // 알림 시간 갱신 (타입별 교체)(빈 리스트면 해당 타입 전부 삭제)

--- a/src/main/java/com/example/pace/domain/member/service/command/SettingCommandService.java
+++ b/src/main/java/com/example/pace/domain/member/service/command/SettingCommandService.java
@@ -7,7 +7,6 @@ import com.example.pace.domain.member.entity.Member;
 import com.example.pace.domain.member.entity.ReminderTime;
 import com.example.pace.domain.member.entity.Setting;
 import com.example.pace.domain.member.enums.AlarmType;
-import com.example.pace.domain.member.enums.CalendarType;
 import com.example.pace.domain.member.exception.MemberException;
 import com.example.pace.domain.member.exception.code.MemberErrorCode;
 import com.example.pace.domain.member.exception.code.SettingErrorCode;
@@ -58,12 +57,14 @@ public class SettingCommandService {
         Setting setting = settingRepository.findByMember(member)
                 .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
+        Long calendarId = parseCalendarId(request.getCalendarId());
+
         setting.update(
                 request.getEarlyArrivalTime(),
                 request.getIsNotiEnabled(),
                 request.getIsLocEnabled(),
                 request.getIsReminderActive(),
-                request.getCalendarType()
+                calendarId
         );
 
         if (request.getAlarms() != null) {
@@ -71,6 +72,17 @@ public class SettingCommandService {
         }
 
         return SettingConverter.toResponse(setting);
+    }
+
+    private Long parseCalendarId(String raw) {
+        if (raw == null) {
+            return null; // calendarId를 필수로 만들 거면 여기서 예외로 바꿔도 됨
+        }
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            throw new SettingException(SettingErrorCode.INVALID_CALENDAR_ID);
+        }
     }
 
     public void applyAlarms(Setting setting, List<SettingUpdateRequestDTO.Alarm> alarms) {
@@ -133,7 +145,7 @@ public class SettingCommandService {
                 .isLocEnabled(false)
                 .earlyArrivalTime(20)
                 .isReminderActive(true)
-                .calendarType(CalendarType.GOOGLE)
+                .calendarId(null)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
#118  

## ✨ 작업 내용 요약
프론트 요구사항에 맞춰 기존 calendarType(enum) 기반 구조를 제거하고, calendarId를 String으로 수신 → 서버에서 Long으로 변환 → DB에 저장하도록 온보딩/세팅 로직을 변경했습니다.

## 🛠️ 주요 변경 사항
calendarType 필드/로직 제거 및 calendarId(Long) 기반으로 구조 변경

Onboarding/Setting DTO에서 calendarId를 String으로 수신하도록 수정

Service 계층에서 calendarId 형식 검증 및 Long.parseLong() 변환 로직 추가 (형식 오류 시 예외 처리)

Setting 엔티티에 calendar_id 컬럼 매핑 및 업데이트 로직 반영

SettingConverter/ResponseDTO에서 calendarId 응답 필드로 통일

Swagger 로컬 테스트 및 DB 저장 정상 동작 확인


## 📚 체크리스트
- [ ] 팀 컨벤션에 맞는 커밋 메시지를 작성했나요?
- [ ] 로컬 환경에서 정상 작동하는지 확인했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?

### 📸 테스트 결과 사진
<!-- 스웨거나 포스트맨 등을 통해 응답 결과 확인 캡쳐본을 넣어주세요! -->

### 🗣️ 리뷰어에게(선택)
<!-- 특히 꼼꼼히 봐주었으면 하는 부분이나 질문을 적어주세요! -->
