### PR TITLE
feat: 버스 실시간 도착 정보 조회를 위한 출발 정류장 조회 API 구현

### DIFF
--- a/src/main/java/com/example/pace/domain/transit/controller/TransitController.java
+++ b/src/main/java/com/example/pace/domain/transit/controller/TransitController.java
@@ -1,11 +1,16 @@
 package com.example.pace.domain.transit.controller;
 
 import com.example.pace.domain.transit.controller.docs.TransitControllerDocs;
+import com.example.pace.domain.transit.dto.request.BusInfoReqDTO;
 import com.example.pace.domain.transit.dto.request.SubwayArrivalReqDTO;
+import com.example.pace.domain.transit.dto.response.BusInfoResDTO;
 import com.example.pace.domain.transit.dto.response.SubwayArrivalResDTO.SubwayArrivalInfoDTO;
 import com.example.pace.domain.transit.exception.code.SubwayApiSuccessCode;
+import com.example.pace.domain.transit.exception.code.TransitSuccessCode;
+import com.example.pace.domain.transit.service.BusNetworkService;
 import com.example.pace.domain.transit.service.query.SubwayApiQueryService;
 import com.example.pace.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/transit")
 public class TransitController implements TransitControllerDocs {
     private final SubwayApiQueryService subwayApiQueryService;
+    private final BusNetworkService busNetworkService;
 
     @GetMapping("/arrivals")
     public ApiResponse<List<SubwayArrivalInfoDTO>> getArrivals(
@@ -26,6 +32,20 @@ public class TransitController implements TransitControllerDocs {
         return ApiResponse.onSuccess(
                 SubwayApiSuccessCode.SUBWAY_API_SUCCESS,
                 subwayApiQueryService.getLiveSubwayStation(request)
+        );
+    }
+
+    @GetMapping("/bus/start-station")
+    public ApiResponse<BusInfoResDTO.BusInfoDTO> searchBusStartStation(
+            @Valid @ModelAttribute BusInfoReqDTO.BusStartStationDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                TransitSuccessCode.TRANSIT_BUS_OK,
+                busNetworkService.searchStartStationInfo(
+                        request.getLineName(),
+                        request.getStartStation(),
+                        request.getEndStation()
+                )
         );
     }
 }

--- a/src/main/java/com/example/pace/domain/transit/controller/docs/TransitControllerDocs.java
+++ b/src/main/java/com/example/pace/domain/transit/controller/docs/TransitControllerDocs.java
@@ -1,6 +1,8 @@
 package com.example.pace.domain.transit.controller.docs;
 
+import com.example.pace.domain.transit.dto.request.BusInfoReqDTO;
 import com.example.pace.domain.transit.dto.request.SubwayArrivalReqDTO;
+import com.example.pace.domain.transit.dto.response.BusInfoResDTO;
 import com.example.pace.domain.transit.dto.response.SubwayArrivalResDTO.SubwayArrivalInfoDTO;
 import com.example.pace.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,5 +19,13 @@ public interface TransitControllerDocs {
     )
     ApiResponse<List<SubwayArrivalInfoDTO>> getArrivals(
             SubwayArrivalReqDTO.SubwayArrivalDTO request
+    );
+
+    @Operation(
+            summary = "버스 실시간 도착 정보 조회를 위한 출발 정류장 식별자 조회",
+            description = "버스 노선 번호, 출발 정류장 이름, 목적지 정류장 이름을 입력받아 사용자가 탑승해야 할 정확한 방향의 출발 정류장 노드 ID(nodeId), 노선 ID(routeId), 정류장 순번(sequence)을 반환합니다. 이 정보는 공공데이터 포털 등 실시간 버스 도착 정보 API를 호출하는 데 사용됩니다."
+    )
+    ApiResponse<BusInfoResDTO.BusInfoDTO> searchBusStartStation(
+            BusInfoReqDTO.BusStartStationDTO request
     );
 }

--- a/src/main/java/com/example/pace/domain/transit/dto/request/BusInfoReqDTO.java
+++ b/src/main/java/com/example/pace/domain/transit/dto/request/BusInfoReqDTO.java
@@ -1,4 +1,20 @@
 package com.example.pace.domain.transit.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 public class BusInfoReqDTO {
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class BusStartStationDTO {
+        @NotBlank(message = "노선 번호는 필수입니다.")
+        String lineName;
+        @NotBlank(message = "출발 정류장 이름은 필수입니다.")
+        String startStation;
+        @NotBlank(message = "도착 정류장 이름은 필수입니다.")
+        String endStation;
+    }
 }

--- a/src/main/java/com/example/pace/domain/transit/dto/response/BusInfoResDTO.java
+++ b/src/main/java/com/example/pace/domain/transit/dto/response/BusInfoResDTO.java
@@ -1,4 +1,18 @@
 package com.example.pace.domain.transit.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class BusInfoResDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class BusInfoDTO {
+        private String routeId;
+        private String nodeId;
+        private Integer sequence;
+    }
 }

--- a/src/main/java/com/example/pace/domain/transit/entity/BusInfo.java
+++ b/src/main/java/com/example/pace/domain/transit/entity/BusInfo.java
@@ -34,6 +34,9 @@ public class BusInfo {
     @Column(name = "bus_route_id", nullable = false)
     private String busRouteId; // 노선 ID
 
+    @Column(name = "node_id", nullable = false)
+    private String nodeId;
+
     @Column(name = "line_name", nullable = false)
     private String lineName; // 노선 명 (버스 번호, 예: 150, 143)
 

--- a/src/main/java/com/example/pace/domain/transit/exception/TransitException.java
+++ b/src/main/java/com/example/pace/domain/transit/exception/TransitException.java
@@ -1,7 +1,10 @@
 package com.example.pace.domain.transit.exception;
 
-public class TransitException extends RuntimeException {
-  public TransitException(String message) {
-    super(message);
-  }
+import com.example.pace.global.apiPayload.code.BaseErrorCode;
+import com.example.pace.global.apiPayload.exception.GeneralException;
+
+public class TransitException extends GeneralException {
+    public TransitException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/com/example/pace/domain/transit/exception/code/TransitErrorCode.java
+++ b/src/main/java/com/example/pace/domain/transit/exception/code/TransitErrorCode.java
@@ -1,4 +1,21 @@
 package com.example.pace.domain.transit.exception.code;
 
-public enum TransitErrorCode {
+import com.example.pace.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum TransitErrorCode implements BaseErrorCode {
+    TRANSIT_BUS_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "조회된 버스 정보가 없습니다.",
+            "TRANSIT_BUS404_1"
+    ),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
 }

--- a/src/main/java/com/example/pace/domain/transit/exception/code/TransitSuccessCode.java
+++ b/src/main/java/com/example/pace/domain/transit/exception/code/TransitSuccessCode.java
@@ -1,4 +1,21 @@
 package com.example.pace.domain.transit.exception.code;
 
-public enum TransitSuccessCode {
+import com.example.pace.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum TransitSuccessCode implements BaseSuccessCode {
+    TRANSIT_BUS_OK(
+            HttpStatus.OK,
+            "출발지역 버스 정보를 성공적으로 조회하였습니다.",
+            "TRANSIT_BUS200_1"
+    ),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
 }

--- a/src/main/java/com/example/pace/domain/transit/loader/BusDataLoader.java
+++ b/src/main/java/com/example/pace/domain/transit/loader/BusDataLoader.java
@@ -72,6 +72,7 @@ public class BusDataLoader implements CommandLineRunner {
                     String routeId = getCellValue(row.getCell(0));
                     String lineName = getCellValue(row.getCell(1));
                     Integer sequence = (int) Double.parseDouble(getCellValue(row.getCell(2))); // 엑셀 숫자는 기본적으로 Double형
+                    String nodeId = getCellValue(row.getCell(3));
                     String arsId = getCellValue(row.getCell(4));
                     String stationName = getCellValue(row.getCell(5));
                     BigDecimal stationLng = new BigDecimal(getCellValue(row.getCell(6))); // x좌표(경도)
@@ -81,6 +82,7 @@ public class BusDataLoader implements CommandLineRunner {
                             .busRouteId(routeId)
                             .lineName(lineName)
                             .sequence(sequence)
+                            .nodeId(nodeId)
                             .arsId(arsId)
                             .stationName(stationName)
                             .stationLng(stationLng)

--- a/src/main/java/com/example/pace/domain/transit/repository/BusInfoRepository.java
+++ b/src/main/java/com/example/pace/domain/transit/repository/BusInfoRepository.java
@@ -2,14 +2,14 @@ package com.example.pace.domain.transit.repository;
 
 import com.example.pace.domain.transit.entity.BusInfo;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BusInfoRepository extends JpaRepository<BusInfo, Long> {
-
+public interface BusInfoRepository extends JpaRepository<BusInfo, Long>, BusInfoRepositoryCustom {
     // 특정 노선(lineName)에서 출발 순번과 도착 순번 사이의 정류장들을 조회 (순서대로)
     @Query("SELECT b FROM BusInfo b "
             + "WHERE b.lineName = :lineName AND b.sequence >= :startSeq AND b.sequence <= :endSeq "
@@ -19,10 +19,4 @@ public interface BusInfoRepository extends JpaRepository<BusInfo, Long> {
             @Param("startSeq") Integer startSeq,
             @Param("endSeq") Integer endSeq
     );
-
-    // 노선 번호와 정류장 이름으로 특정 정류장 정보 찾기 (순번을 알아내기 위해 사용)
-    List<BusInfo> findByLineNameAndStationName(String lineName, String startStationName);
-
-    // 데이터 중복 적재 방지를 위해 존재 여부 확인
-    boolean existsByBusRouteId(String busRouteId);
 }

--- a/src/main/java/com/example/pace/domain/transit/repository/BusInfoRepositoryCustom.java
+++ b/src/main/java/com/example/pace/domain/transit/repository/BusInfoRepositoryCustom.java
@@ -1,4 +1,12 @@
 package com.example.pace.domain.transit.repository;
 
+import com.example.pace.domain.transit.entity.BusInfo;
+import java.util.Optional;
+
 public interface BusInfoRepositoryCustom {
+    record BusRoutePair(BusInfo startStation, BusInfo endStation) {
+    }
+
+    // 버스 번호, 탑승지, 하차지를 받아 올바른 방향의 탑승 정류장 정보를 반환
+    Optional<BusRoutePair> findCorrectBusRoute(String lineName, String boardingStopName, String alightingStopName);
 }

--- a/src/main/java/com/example/pace/domain/transit/repository/BusInfoRepositoryCustomImpl.java
+++ b/src/main/java/com/example/pace/domain/transit/repository/BusInfoRepositoryCustomImpl.java
@@ -1,4 +1,49 @@
 package com.example.pace.domain.transit.repository;
 
-public class BusInfoRepositoryCustomImpl {
+import com.example.pace.domain.transit.entity.BusInfo;
+import com.example.pace.domain.transit.entity.QBusInfo;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BusInfoRepositoryCustomImpl implements BusInfoRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<BusRoutePair> findCorrectBusRoute(
+            String lineName,
+            String startStationName,
+            String endStationName
+    ) {
+        QBusInfo boarding = new QBusInfo("boarding"); // 탑승 정류장
+        QBusInfo alighting = new QBusInfo("alighting"); // 하차 정류장
+
+        Tuple result = queryFactory
+                .select(boarding, alighting)
+                .from(boarding)
+                .join(alighting).on(boarding.busRouteId.eq(alighting.busRouteId))
+                .where(
+                        boarding.lineName.eq(lineName),
+                        boarding.stationName.eq(startStationName),
+                        alighting.stationName.eq(endStationName),
+                        // 출발 정류장의 순번이 하차 정류장의 순서보다 작아야 올바른 방향임
+                        boarding.sequence.lt(alighting.sequence)
+                )
+                // 탑승지와 하차지 사이의 정류장 개수 차이가 가장 적은 경로를 우선적으로 정렬
+                .orderBy(alighting.sequence.subtract(boarding.sequence).asc())
+                .fetchFirst();
+
+        if (result == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new BusRoutePair(
+                        result.get(boarding),
+                        result.get(alighting)
+                )
+        );
+    }
 }

--- a/src/main/java/com/example/pace/domain/transit/service/BusNetworkService.java
+++ b/src/main/java/com/example/pace/domain/transit/service/BusNetworkService.java
@@ -1,7 +1,12 @@
 package com.example.pace.domain.transit.service;
 
+import com.example.pace.domain.transit.dto.response.BusInfoResDTO;
+import com.example.pace.domain.transit.dto.response.BusInfoResDTO.BusInfoDTO;
 import com.example.pace.domain.transit.entity.BusInfo;
+import com.example.pace.domain.transit.exception.TransitException;
+import com.example.pace.domain.transit.exception.code.TransitErrorCode;
 import com.example.pace.domain.transit.repository.BusInfoRepository;
+import com.example.pace.domain.transit.repository.BusInfoRepositoryCustom.BusRoutePair;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -16,35 +21,42 @@ import org.springframework.transaction.annotation.Transactional;
 public class BusNetworkService {
     private final BusInfoRepository busInfoRepository;
 
+    // 실시간 도착 정보 조회를 위한 단일 정류장 정보 반환
+    @Transactional(readOnly = true)
+    public BusInfoResDTO.BusInfoDTO searchStartStationInfo(
+            String lineName,
+            String startStation,
+            String endStation
+    ) {
+        BusInfo startStop = busInfoRepository.findCorrectBusRoute(
+                        lineName,
+                        startStation,
+                        endStation
+                )
+                .orElseThrow(() -> new TransitException(TransitErrorCode.TRANSIT_BUS_NOT_FOUND))
+                .startStation();
+
+        return BusInfoResDTO.BusInfoDTO.builder()
+                .nodeId(startStop.getNodeId())
+                .routeId(startStop.getBusRouteId())
+                .sequence(startStop.getSequence())
+                .build();
+    }
+
+    // 출발지부터 도착지 사이의 모든 정류장 목록을 반환
     @Transactional(readOnly = true)
     public List<BusInfo> getStationsBetween(String lineName, String startStation, String endStation) {
-        List<BusInfo> startStopList = busInfoRepository.findByLineNameAndStationName(lineName, startStation);
-        List<BusInfo> endStopList = busInfoRepository.findByLineNameAndStationName(lineName, endStation);
+        BusRoutePair routePair = busInfoRepository.findCorrectBusRoute(
+                        lineName,
+                        startStation,
+                        endStation
+                )
+                .orElseThrow(() -> new TransitException(TransitErrorCode.TRANSIT_BUS_NOT_FOUND));
 
-        if (startStopList.isEmpty() || endStopList.isEmpty()) {
-            log.warn("정류장 정보를 찾을 수 없습니다.: {} ({} -> {})", lineName, startStation, endStation);
-            return Collections.emptyList();
-        }
-
-        BusInfo start = startStopList.getFirst();
-        BusInfo end = endStopList.getFirst();
-
-        int startSeq = start.getSequence();
-        int endSeq = end.getSequence();
-
-        int minSeq = Math.min(startSeq, endSeq);
-        int maxSeq = Math.max(startSeq, endSeq);
-
-        List<BusInfo> path = busInfoRepository.findIntermediateStops(lineName, minSeq, maxSeq);
-
-        if (startSeq > endSeq) {
-            // 역방향인 경우 순번 내림차순 정렬
-            path.sort(Comparator.comparing(BusInfo::getSequence).reversed());
-        } else {
-            // 정방향인 경우 순번 오름차순 정렬
-            path.sort(Comparator.comparing(BusInfo::getSequence));
-        }
-
-        return path;
+        return busInfoRepository.findIntermediateStops(
+                lineName,
+                routePair.startStation().getSequence(),
+                routePair.endStation().getSequence()
+        );
     }
 }

--- a/src/test/java/com/example/pace/domain/transit/service/BusNetworkServiceTest.java
+++ b/src/test/java/com/example/pace/domain/transit/service/BusNetworkServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
+// @Disabled
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // H2로 교체하지 않고 실제 DB 사용
 class BusNetworkServiceTest {
@@ -43,7 +43,7 @@ class BusNetworkServiceTest {
         List<BusInfo> result = busNetworkService.getStationsBetween(lineName, start, end);
 
         assertThat(result).isNotEmpty();
-
+        assertThat(result.getFirst().getNodeId()).isEqualTo("107000163");
         List<String> names = result.stream().map(BusInfo::getStationName).toList();
 
         System.out.println("조회된 경로: " + names);

--- a/src/test/java/com/example/pace/domain/transit/service/BusNetworkServiceUnitTest.java
+++ b/src/test/java/com/example/pace/domain/transit/service/BusNetworkServiceUnitTest.java
@@ -1,4 +1,108 @@
 package com.example.pace.domain.transit.service;
 
+import com.example.pace.domain.transit.dto.response.BusInfoResDTO;
+import com.example.pace.domain.transit.entity.BusInfo;
+import com.example.pace.domain.transit.exception.TransitException;
+import com.example.pace.domain.transit.exception.code.TransitErrorCode;
+import com.example.pace.domain.transit.repository.BusInfoRepository;
+import com.example.pace.domain.transit.repository.BusInfoRepositoryCustom.BusRoutePair;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+// 해당 클래스에서 Mockito를 사용하겠다고 JUnit에게 알려주는 역할
+@ExtendWith(MockitoExtension.class)
 public class BusNetworkServiceUnitTest {
+    // 스프링이 빈을 주입하듯이 Mockito가 아래에서 만든 @Mock 가짜 객체들을 해당 클래스 안에 inject함
+    @InjectMocks
+    private BusNetworkService busNetworkService;
+
+    // 가짜 객체 만들기
+    // 서비스 로직만 테스트하고 싶은데, 실제 DB를 붙이면 너무 느리고 복잡해지기 때문
+    @Mock
+    private BusInfoRepository busInfoRepository;
+
+    @Test
+    @DisplayName("버스 정보 조회 성공: 올바른 방향의 정류장과 종점 방면을 찾는다.")
+    void searchStartStationInfo_Success() {
+        // given 단계
+        String lineName = "1014";
+        String startStationName = "정릉시장입구";
+        String endStationName = "신설동역오거리";
+
+        // 데이터베이스에서 꺼내온 척하는 엔티티를 하나 만듬
+        BusInfo startStation = BusInfo.builder()
+                .lineName(lineName)
+                .stationName(startStationName)
+                .nodeId("107000077")
+                .busRouteId("100100129")
+                .arsId("08167")
+                .sequence(7)
+                .stationLat(BigDecimal.valueOf(37.6084653300))
+                .stationLng(BigDecimal.valueOf(127.0098213000))
+                .build();
+
+        // mock 객체에게 findCorrectBusRoute를 호출하면 BusRoutePair 객체를 반환하라는 의미
+        given(busInfoRepository.findCorrectBusRoute(
+                lineName,
+                startStationName,
+                endStationName
+        )).willReturn(Optional.of(
+                new BusRoutePair(
+                        startStation,
+                        null
+                )
+        ));
+
+        // when 단계
+        BusInfoResDTO.BusInfoDTO response = busNetworkService.searchStartStationInfo(
+                lineName,
+                startStationName,
+                endStationName
+        );
+
+        assertThat(response.getSequence()).isEqualTo(startStation.getSequence());
+        assertThat(response.getNodeId()).isEqualTo(startStation.getNodeId());
+    }
+
+    @Test
+    @DisplayName("실패: 올바른 경로를 찾지 못하면 예외가 발생")
+    void searchStartStationInfo_Failure() {
+        // given
+        // 조회 쿼리가 실행되었을 때 데이터를 못찾아서 빈 객체를 반환한다고 가정
+        given(busInfoRepository.findCorrectBusRoute(anyString(), anyString(), anyString()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> busNetworkService.searchStartStationInfo(
+                "5432",
+                "없는역!",
+                "모르는역!"
+        ))
+                .isInstanceOf(TransitException.class)
+                .hasMessageContaining(TransitErrorCode.TRANSIT_BUS_NOT_FOUND.getMessage());
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## 📌 관련 이슈
<!-- #이슈번호로 관련 이슈를 지정해주세요! ex) #12 --> 
#133 
## ✨ 작업 내용 요약
<!-- 이번 PR에서 무엇을 변경했는지 간단히 적어주세요! -->
- 프론트엔드에서 실시간 버스 도착 정보 API를 호출하기 위해 필요한 요청 필드 값들(nodeId, routeId, sequence)을 반환하는 API를 구현했습니다. 이 과정에서 노선의 상/하행 방향을 정확히 판별하기 위해 DB 조회 성능을 최적화(단일 쿼리 조회)하였으며, 순환 노선에서 동일 정류장이 여러 번 조회되는 이슈를 해결하여 기존 버스 경로 상세 조회 로직 안정성까지 개선시켰습니다.
## 🛠️ 주요 변경 사항
<!-- 변경 사항을 좀 더 구체적으로 작성해주세요! -->
- 신규 API 엔드포인트 추가
       - GET /api/v1/transit/bus/start-station 컨트롤러 추가
       - 버스 번호(lineName), 출발지(startStation), 도착지(endStation)를 입력받아 올바른 방향의 탑승 정류장 핵심 정보(DTO) 반환
       - 관련 요청/응답 DTO(BusInfoReqDTO, BusInfoResDTO) 추가 및 Swagger 문서화 완료
- 데이터베이스 조회 로직 고도화
       - BusInfoRepositoryCustom 및 구현체 추가
       - 탑승 정류장의 순번(sequence) < 하차 정류장의 순번 조건을 통해 상/하행 방향 혼동 문제 해결
       - 쿼리 최적화: QueryDSL의 Tuple을 활용해 단 한 번의 쿼리로 출발지/도착지 데이터 쌍(BusRoutePair 레코드)을 모두 가져오도록 개선 (N+1 및 중복 쿼리 방지)
       
- BusNetworkService 리팩토링
       - 신규 API를 위한 searchStartStationInfo 비즈니스 로직 추가
       - 기존 경로 상세 조회 로직(getStationsBetween)을 QueryDSL 기반으로 뜯어고쳐, 불필요한 Java 단의 역방향 판단/정렬 코드를 모두 제거하고 간소화
- 테스트 코드 작성
       - BusNetworkServiceUnitTest 추가
       - Mockito를 활용하여 DB 연결 없이 순수 비즈니스 로직 단위 테스트 수행
       - 정상 조회 및 각종 예외 상황(TRANSIT_BUS_NOT_FOUND)에 대한 검증 완료
## 📚 체크리스트
- [x] 팀 컨벤션에 맞는 커밋 메시지를 작성했나요?
- [x] 로컬 환경에서 정상 작동하는지 확인했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?

### 📸 테스트 결과 사진
<!-- 스웨거나 포스트맨 등을 통해 응답 결과 확인 캡쳐본을 넣어주세요! -->
<img width="656" height="264" alt="image" src="https://github.com/user-attachments/assets/253a4e04-b1b1-4667-a726-68668c12e584" />

### 🗣️ 리뷰어에게(선택)
<!-- 특히 꼼꼼히 봐주었으면 하는 부분이나 질문을 적어주세요! -->
